### PR TITLE
Fix worker path for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,21 @@
-import { defineConfig } from 'vite'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
-import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const workerDir = dirname(require.resolve('sql.js-httpvfs/dist/sqlite.worker.js'));
+const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  server: {
+    fs: {
+      allow: [projectRoot, workerDir],
+    },
+  },
   // resolve: {
   //   alias: {
   //     '@muonw/powertable': fileURLToPath(new URL('./node_modules/@muonw/powertable/index.js', import.meta.url))


### PR DESCRIPTION
## Summary
- add `server.fs.allow` to Vite config so worker script loads under Yarn PnP

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6842f7d1716c832caf18609a23f66d32